### PR TITLE
CRUD endpoints finished with extensive testing, unit and integration :D

### DIFF
--- a/src/app/controllers/applicationcontroller/applicationcontroller.go
+++ b/src/app/controllers/applicationcontroller/applicationcontroller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/EaseApp/web-backend/src/app/controllers/helpers"
 	"github.com/EaseApp/web-backend/src/app/models"
+	"github.com/EaseApp/web-backend/src/lib"
 	"github.com/gorilla/mux"
 )
 
@@ -55,4 +56,90 @@ func DeleteApplicationHandler(w http.ResponseWriter, req *http.Request, user *mo
 	}
 
 	json.NewEncoder(w).Encode(user.Applications)
+}
+
+// appDataReqParams holds the params needed for the data handlers below.
+type appDataReqParams struct {
+	PathStr string      `json:"path"`
+	Data    interface{} `json:"data"`
+	Path    lib.Path    `json:"-"`
+}
+
+var successResponse = struct {
+	Success bool `json:"success"`
+}{true}
+
+// SaveApplicationDataHandler handles saving app data.
+func SaveApplicationDataHandler(w http.ResponseWriter, req *http.Request, app *models.Application) {
+	params, err := parseAppDataParams(w, req)
+	if err != nil {
+		return
+	}
+
+	err = querier.SaveApplicationData(app, params.Path, params.Data)
+	if err != nil {
+		friendlyErr := errors.New("Failed to save application data")
+		log.Println(friendlyErr, ": ", err)
+		helpers.SendError(http.StatusInternalServerError, friendlyErr, w)
+		return
+	}
+
+	json.NewEncoder(w).Encode(successResponse)
+}
+
+// ReadApplicationDataHandler handles reading app data.
+func ReadApplicationDataHandler(w http.ResponseWriter, req *http.Request, app *models.Application) {
+	params, err := parseAppDataParams(w, req)
+	if err != nil {
+		return
+	}
+
+	data, err := querier.ReadApplicationData(app, params.Path)
+	if err != nil {
+		friendlyErr := errors.New("Failed to read application data")
+		log.Println(friendlyErr, ": ", err)
+		helpers.SendError(http.StatusInternalServerError, friendlyErr, w)
+		return
+	}
+
+	json.NewEncoder(w).Encode(data)
+}
+
+// DeleteApplicationDataHandler handles deleting app data.
+func DeleteApplicationDataHandler(w http.ResponseWriter, req *http.Request, app *models.Application) {
+	params, err := parseAppDataParams(w, req)
+	if err != nil {
+		return
+	}
+
+	err = querier.DeleteApplicationData(app, params.Path)
+	if err != nil {
+		friendlyErr := errors.New("Failed to delete application data")
+		log.Println(friendlyErr, ": ", err)
+		helpers.SendError(http.StatusInternalServerError, friendlyErr, w)
+		return
+	}
+
+	json.NewEncoder(w).Encode(successResponse)
+}
+
+// parseAppDataParams parses the given app data params and sends an error if they're invalid.
+func parseAppDataParams(w http.ResponseWriter, req *http.Request) (appDataReqParams, error) {
+	var params appDataReqParams
+
+	err := json.NewDecoder(req.Body).Decode(&params)
+	if err != nil {
+		friendlyErr := errors.New("Invalid JSON: " + err.Error())
+		helpers.SendError(http.StatusBadRequest, friendlyErr, w)
+		return params, err
+	}
+
+	params.Path, err = lib.ParsePath(params.PathStr)
+	if err != nil {
+		friendlyErr := errors.New("Invalid Path: " + err.Error())
+		helpers.SendError(http.StatusBadRequest, friendlyErr, w)
+		return params, err
+	}
+
+	return params, nil
 }

--- a/src/app/controllers/applicationcontroller/applicationcontroller.go
+++ b/src/app/controllers/applicationcontroller/applicationcontroller.go
@@ -1,0 +1,58 @@
+package applicationcontroller
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/EaseApp/web-backend/src/app/controllers/helpers"
+	"github.com/EaseApp/web-backend/src/app/models"
+	"github.com/gorilla/mux"
+)
+
+var querier *models.ModelQuerier
+
+// Init sets the hacky global ModelQuerier to the given querier.
+// This is to simplify the code because for this school project, we don't need
+// to have perfect dependency injection practices.
+func Init(querierX *models.ModelQuerier) {
+	querier = querierX
+}
+
+// CreateApplicationHandler handles creating applications for the authenticated user.
+func CreateApplicationHandler(w http.ResponseWriter, req *http.Request, user *models.User) {
+	vars := mux.Vars(req)
+	appName := vars["application"]
+	newApp, err := querier.CreateApplication(user, appName)
+
+	// TODO: Check that the application doesn't already exist.
+	if err != nil {
+		friendlyErr := errors.New("Could not create application")
+		log.Println(friendlyErr.Error() + ".  Error: " + err.Error())
+		helpers.SendError(http.StatusInternalServerError, friendlyErr, w)
+		return
+	}
+	json.NewEncoder(w).Encode(newApp)
+}
+
+// ListApplicationsHandler handles listing the applications for the authenticated user.
+func ListApplicationsHandler(w http.ResponseWriter, req *http.Request, user *models.User) {
+	json.NewEncoder(w).Encode(user.Applications)
+}
+
+// DeleteApplicationHandler handles deleting the authenticated user's application.
+func DeleteApplicationHandler(w http.ResponseWriter, req *http.Request, user *models.User) {
+	vars := mux.Vars(req)
+	appName := vars["application"]
+
+	user, err := querier.DeleteApplication(user, appName)
+	if err != nil {
+		friendlyErr := errors.New("Failed to delete application")
+		log.Println(friendlyErr.Error() + ".  Error: " + err.Error())
+		helpers.SendError(http.StatusInternalServerError, friendlyErr, w)
+		return
+	}
+
+	json.NewEncoder(w).Encode(user.Applications)
+}

--- a/src/app/controllers/usercontroller/usercontroller.go
+++ b/src/app/controllers/usercontroller/usercontroller.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/EaseApp/web-backend/src/app/controllers/helpers"
 	"github.com/EaseApp/web-backend/src/app/models"
-	"github.com/gorilla/mux"
 )
 
 var querier *models.ModelQuerier
@@ -62,43 +61,6 @@ func SignUpHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	json.NewEncoder(w).Encode(user)
-}
-
-// CreateApplicationHandler handles creating applications for the authenticated user.
-func CreateApplicationHandler(w http.ResponseWriter, req *http.Request, user *models.User) {
-	vars := mux.Vars(req)
-	appName := vars["application"]
-	newApp, err := querier.CreateApplication(user, appName)
-
-	// TODO: Check that the application doesn't already exist.
-	if err != nil {
-		friendlyErr := errors.New("Could not create application")
-		log.Println(friendlyErr.Error() + ".  Error: " + err.Error())
-		helpers.SendError(http.StatusInternalServerError, friendlyErr, w)
-		return
-	}
-	json.NewEncoder(w).Encode(newApp)
-}
-
-// ListApplicationsHandler handles listing the applications for the authenticated user.
-func ListApplicationsHandler(w http.ResponseWriter, req *http.Request, user *models.User) {
-	json.NewEncoder(w).Encode(user.Applications)
-}
-
-// DeleteApplicationHandler handles deleting the authenticated user's application.
-func DeleteApplicationHandler(w http.ResponseWriter, req *http.Request, user *models.User) {
-	vars := mux.Vars(req)
-	appName := vars["application"]
-
-	user, err := querier.DeleteApplication(user, appName)
-	if err != nil {
-		friendlyErr := errors.New("Failed to delete application")
-		log.Println(friendlyErr.Error() + ".  Error: " + err.Error())
-		helpers.SendError(http.StatusInternalServerError, friendlyErr, w)
-		return
-	}
-
-	json.NewEncoder(w).Encode(user.Applications)
 }
 
 // parseUserParams parses user params and returns an error to the user

--- a/src/app/models/application.go
+++ b/src/app/models/application.go
@@ -220,8 +220,3 @@ func (querier *ModelQuerier) ReadApplicationData(
 	log.Println("ERROR: This should never be reached.")
 	return nil, nil
 }
-
-// DeleteApplicationData deletes the application's data at the given path.
-func (querier *ModelQuerier) ReadApplicationData(
-	app *Application, path lib.Path) error {
-}

--- a/src/app/models/application.go
+++ b/src/app/models/application.go
@@ -101,7 +101,7 @@ func (querier *ModelQuerier) AuthenticateApplication(
 
 // SaveApplicationData saves the given data to the application's table at the given path.
 func (querier *ModelQuerier) SaveApplicationData(
-	app Application, path lib.Path, data interface{}) error {
+	app *Application, path lib.Path, data interface{}) error {
 	if path.IsRoot() {
 		return errors.New("Cannot save data to application root")
 	}
@@ -152,9 +152,7 @@ func (querier *ModelQuerier) SaveApplicationData(
 	}
 
 	// Upsert the given data at the nested path.
-	_, err = r.Table(app.TableName).Get(docID).Insert(
-		nestedDataQuery, r.InsertOpts{Conflict: "replace"},
-	).RunWrite(querier.session)
+	_, err = r.Table(app.TableName).Get(docID).Update(nestedDataQuery).RunWrite(querier.session)
 
 	return err
 }

--- a/src/app/models/application.go
+++ b/src/app/models/application.go
@@ -165,18 +165,18 @@ func (querier *ModelQuerier) ReadApplicationData(
 		return nil, nil
 	}
 
-	var data interface{}
-	err = res.One(&data)
+	var doc map[string]interface{}
+	err = res.One(&doc)
 	if err != nil {
 		return nil, err
 	}
 
-	// If nested data isn't requested, return it.
+	// If nested data isn't requested, return all the doc's data.
 	if len(path.RemainingSegments) == 0 {
-		return data, nil
+		return doc["data"], nil
 	}
 
-	nextMapLevel, ok := data.(map[string]interface{})
+	nextMapLevel, ok := doc["data"].(map[string]interface{})
 	if !ok {
 		return nil, nil
 	}

--- a/src/app/models/application_test.go
+++ b/src/app/models/application_test.go
@@ -69,28 +69,22 @@ func TestSaveAndReadApplicationData(t *testing.T) {
 			float64(10),
 		},
 		{
-			"/hello/world/hi",
-			"/hello/world",
+			"/a/b/c",
+			"/a/b",
 			10,
 			map[string]interface{}{"hi": float64(10)},
 		},
 		{
-			"/hello/world/hi",
-			"/hello/world",
-			10,
-			map[string]interface{}{"hi": float64(10)},
-		},
-		{
-			"/hello/world/hi",
-			"/hello/world/hi",
+			"/yes/no/maybe",
+			"/yes/no/maybe",
 			map[string]interface{}{"hello": "wassuuuup", "multiple": []int{1, 2}},
 			map[string]interface{}{"hello": "wassuuuup", "multiple": []interface{}{float64(1), float64(2)}},
 		},
 		{
-			"/hello",
+			"/howdy",
 			"/",
 			map[string]interface{}{"yeah": "wassuuuup", "multiple": []int{1, 2}},
-			map[string]interface{}{"hello": map[string]interface{}{"yeah": "wassuuuup", "multiple": []interface{}{float64(1), float64(2)}}},
+			map[string]interface{}{"howdy": map[string]interface{}{"yeah": "wassuuuup", "multiple": []interface{}{float64(1), float64(2)}}},
 		},
 	}
 
@@ -104,5 +98,7 @@ func TestSaveAndReadApplicationData(t *testing.T) {
 		readPath, err := lib.ParsePath(testcase.readPath)
 		data, err := querier.ReadApplicationData(app, readPath)
 		assert.Equal(t, testcase.expectedReadData, data)
+		p, err := lib.ParsePath("/hello")
+		querier.SaveApplicationData(app, p, nil)
 	}
 }

--- a/src/app/models/application_test.go
+++ b/src/app/models/application_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/EaseApp/web-backend/src/lib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,4 +41,24 @@ func TestAuthenticateApplication(t *testing.T) {
 	authedApp, err = querier.AuthenticateApplication("user", "app2", app2.AppToken)
 	assert.NoError(t, err)
 	assert.Equal(t, app2, authedApp)
+}
+
+func TestSaveAndReadApplicationData(t *testing.T) {
+	querier := getModelQuerier(t)
+
+	// Create a user with an application.
+	user, err := NewUser("user", "pass")
+	require.NoError(t, err)
+
+	_, err = querier.Save(user)
+	require.NoError(t, err)
+
+	app, err := querier.CreateApplication(user, "app1")
+	require.NoError(t, err)
+
+	path, err := lib.ParsePath("/hello/world/hi")
+	require.NoError(t, err)
+
+	err = querier.SaveApplicationData(app, path, 10)
+	assert.NoError(t, err)
 }

--- a/src/app/models/application_test.go
+++ b/src/app/models/application_test.go
@@ -63,6 +63,12 @@ func TestSaveAndReadApplicationData(t *testing.T) {
 		expectedReadData interface{}
 	}{
 		{
+			"/howdy",
+			"/",
+			map[string]interface{}{"yeah": "wassuuuup", "multiple": []int{1, 2}},
+			map[string]interface{}{"howdy": map[string]interface{}{"yeah": "wassuuuup", "multiple": []interface{}{float64(1), float64(2)}}},
+		},
+		{
 			"/hello/world/hi",
 			"/hello/world/hi",
 			10,
@@ -72,19 +78,13 @@ func TestSaveAndReadApplicationData(t *testing.T) {
 			"/a/b/c",
 			"/a/b",
 			10,
-			map[string]interface{}{"hi": float64(10)},
+			map[string]interface{}{"c": float64(10)},
 		},
 		{
 			"/yes/no/maybe",
 			"/yes/no/maybe",
 			map[string]interface{}{"hello": "wassuuuup", "multiple": []int{1, 2}},
 			map[string]interface{}{"hello": "wassuuuup", "multiple": []interface{}{float64(1), float64(2)}},
-		},
-		{
-			"/howdy",
-			"/",
-			map[string]interface{}{"yeah": "wassuuuup", "multiple": []int{1, 2}},
-			map[string]interface{}{"howdy": map[string]interface{}{"yeah": "wassuuuup", "multiple": []interface{}{float64(1), float64(2)}}},
 		},
 	}
 

--- a/src/integration/integration_test.go
+++ b/src/integration/integration_test.go
@@ -321,11 +321,11 @@ func TestSaveReadAndDeleteAppDataEndpoints(t *testing.T) {
 	appToken := createTestApplication(server.URL, t)
 
 	resp := sendJSON(`{"path":"/hello", "data":{"nested":"objects", "yes": 1}}`,
-		appToken, server.URL, "/api/data/ronswanson/bestappevar", "POST", t)
+		appToken, server.URL, "/data/ronswanson/bestappevar", "POST", t)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	resp = sendJSON(`{"path":"/hello"}`,
-		appToken, server.URL, "/api/data/ronswanson/bestappevar", "GET", t)
+		appToken, server.URL, "/data/ronswanson/bestappevar", "GET", t)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var data1 interface{}
@@ -334,11 +334,11 @@ func TestSaveReadAndDeleteAppDataEndpoints(t *testing.T) {
 	assert.Equal(t, interface{}(map[string]interface{}{"nested": "objects", "yes": float64(1)}), data1)
 
 	resp = sendJSON(`{"path":"/hello/yes"}`,
-		appToken, server.URL, "/api/data/ronswanson/bestappevar", "DELETE", t)
+		appToken, server.URL, "/data/ronswanson/bestappevar", "DELETE", t)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	resp = sendJSON(`{"path":"/hello"}`,
-		appToken, server.URL, "/api/data/ronswanson/bestappevar", "GET", t)
+		appToken, server.URL, "/data/ronswanson/bestappevar", "GET", t)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var data2 interface{}
@@ -348,7 +348,7 @@ func TestSaveReadAndDeleteAppDataEndpoints(t *testing.T) {
 
 	// Verify data can't be accessed with a bad token.
 	resp = sendJSON(`{"path":"/hello"}`,
-		"iamtoken", server.URL, "/api/data/ronswanson/bestappevar", "GET", t)
+		"iamtoken", server.URL, "/data/ronswanson/bestappevar", "GET", t)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
 	var data3 interface{}

--- a/src/integration/integration_test.go
+++ b/src/integration/integration_test.go
@@ -346,6 +346,16 @@ func TestSaveReadAndDeleteAppDataEndpoints(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, interface{}(map[string]interface{}{"nested": "objects"}), data2)
 
+	// Verify data can't be accessed with a bad token.
+	resp = sendJSON(`{"path":"/hello"}`,
+		"iamtoken", server.URL, "/api/data/ronswanson/bestappevar", "GET", t)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	var data3 interface{}
+	err = json.NewDecoder(resp.Body).Decode(&data3)
+	assert.NoError(t, err)
+	assert.Equal(t, interface{}(map[string]interface{}{"error_code": float64(401), "error": "Invalid application token"}), data3)
+
 	// Delete the created application table.
 	r.DB("test").TableDrop("ronswanson_bestappevar").RunWrite(client.Session)
 }

--- a/src/lib/path.go
+++ b/src/lib/path.go
@@ -1,0 +1,39 @@
+package lib
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// Path represents an application data path.
+type Path struct {
+	OriginalString    string
+	TableName         string
+	RemainingSegments []string
+}
+
+var pathRegex = regexp.MustCompile("^(/|/[^/]+(/[^/]+)*)$")
+
+// ParsePath parses a string into a path.
+func ParsePath(pathStr string) (Path, error) {
+	path := Path{OriginalString: pathStr}
+	if len(pathStr) < 1 {
+		return path, errors.New("Path cannot be empty")
+	}
+	if pathStr[0] != '/' {
+		return path, errors.New("Path must begin with slash")
+	}
+	if !pathRegex.MatchString(pathStr) {
+		return path, errors.New("Invalid path format")
+	}
+	segments := strings.Split(pathStr, "/")
+	path.TableName = segments[1]
+	path.RemainingSegments = segments[2:]
+	return path, nil
+}
+
+// IsRoot returns true iff a path refers to the root of all docs.
+func (p Path) IsRoot() bool {
+	return p.TableName == ""
+}

--- a/src/lib/path.go
+++ b/src/lib/path.go
@@ -9,7 +9,7 @@ import (
 // Path represents an application data path.
 type Path struct {
 	OriginalString    string
-	TableName         string
+	TopLevelDocName   string
 	RemainingSegments []string
 }
 
@@ -28,12 +28,12 @@ func ParsePath(pathStr string) (Path, error) {
 		return path, errors.New("Invalid path format")
 	}
 	segments := strings.Split(pathStr, "/")
-	path.TableName = segments[1]
+	path.TopLevelDocName = segments[1]
 	path.RemainingSegments = segments[2:]
 	return path, nil
 }
 
 // IsRoot returns true iff a path refers to the root of all docs.
 func (p Path) IsRoot() bool {
-	return p.TableName == ""
+	return p.TopLevelDocName == ""
 }

--- a/src/lib/path_test.go
+++ b/src/lib/path_test.go
@@ -35,14 +35,14 @@ func TestParsePath(t *testing.T) {
 		},
 		{
 			"/",
-			Path{OriginalString: "/", TableName: "", RemainingSegments: []string{}},
+			Path{OriginalString: "/", TopLevelDocName: "", RemainingSegments: []string{}},
 			nil,
 		},
 		{
 			"/hi/there",
 			Path{
 				OriginalString:    "/hi/there",
-				TableName:         "hi",
+				TopLevelDocName:   "hi",
 				RemainingSegments: []string{"there"}},
 			nil,
 		},
@@ -50,7 +50,7 @@ func TestParsePath(t *testing.T) {
 			"/hi/there/sup",
 			Path{
 				OriginalString:    "/hi/there/sup",
-				TableName:         "hi",
+				TopLevelDocName:   "hi",
 				RemainingSegments: []string{"there", "sup"}},
 			nil,
 		},

--- a/src/lib/path_test.go
+++ b/src/lib/path_test.go
@@ -1,0 +1,73 @@
+package lib
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePath(t *testing.T) {
+	testcases := []struct {
+		input        string
+		expectedPath Path
+		expectedErr  error
+	}{
+		{
+			"",
+			Path{OriginalString: ""},
+			errors.New("Path cannot be empty"),
+		},
+		{
+			"hi/there",
+			Path{OriginalString: "hi/there"},
+			errors.New("Path must begin with slash"),
+		},
+		{
+			"/hi//there",
+			Path{OriginalString: "/hi//there"},
+			errors.New("Invalid path format"),
+		},
+		{
+			"/hi/there/",
+			Path{OriginalString: "/hi/there/"},
+			errors.New("Invalid path format"),
+		},
+		{
+			"/",
+			Path{OriginalString: "/", TableName: "", RemainingSegments: []string{}},
+			nil,
+		},
+		{
+			"/hi/there",
+			Path{
+				OriginalString:    "/hi/there",
+				TableName:         "hi",
+				RemainingSegments: []string{"there"}},
+			nil,
+		},
+		{
+			"/hi/there/sup",
+			Path{
+				OriginalString:    "/hi/there/sup",
+				TableName:         "hi",
+				RemainingSegments: []string{"there", "sup"}},
+			nil,
+		},
+	}
+
+	for _, testcase := range testcases {
+		path, err := ParsePath(testcase.input)
+		assert.Equal(t, testcase.expectedPath, path)
+		assert.Equal(t, testcase.expectedErr, err)
+
+		// Test Path.IsRoot.
+		if testcase.expectedErr == nil {
+			if testcase.input == "/" {
+				assert.True(t, path.IsRoot())
+			} else {
+				assert.False(t, path.IsRoot())
+			}
+		}
+	}
+}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -67,11 +67,11 @@ func createRoutingMux(client *db.Client) *mux.Router {
 		helpers.RequireAPIToken(applicationcontroller.DeleteApplicationHandler)).Methods("DELETE")
 
 	// Application data routes.
-	router.HandleFunc("/data/{username}/{app_name}",
+	router.HandleFunc("/api/data/{username}/{app_name}",
 		helpers.RequireAppToken(applicationcontroller.ReadApplicationDataHandler)).Methods("GET")
-	router.HandleFunc("/data/{username}/{app_name}",
+	router.HandleFunc("/api/data/{username}/{app_name}",
 		helpers.RequireAppToken(applicationcontroller.SaveApplicationDataHandler)).Methods("POST")
-	router.HandleFunc("/data/{username}/{app_name}",
+	router.HandleFunc("/api/data/{username}/{app_name}",
 		helpers.RequireAppToken(applicationcontroller.DeleteApplicationDataHandler)).Methods("DELETE")
 
 	return router

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/EaseApp/web-backend/src/app/controllers/applicationcontroller"
 	"github.com/EaseApp/web-backend/src/app/controllers/helpers"
 	"github.com/EaseApp/web-backend/src/app/controllers/usercontroller"
 	"github.com/EaseApp/web-backend/src/app/models"
@@ -46,6 +47,7 @@ func createRoutingMux(client *db.Client) *mux.Router {
 	querier := models.NewModelQuerier(client.Session)
 
 	usercontroller.Init(querier)
+	applicationcontroller.Init(querier)
 	helpers.Init(querier)
 
 	router := mux.NewRouter()
@@ -58,11 +60,11 @@ func createRoutingMux(client *db.Client) *mux.Router {
 	router.HandleFunc("/users/sign_up", usercontroller.SignUpHandler).Methods("POST")
 	router.HandleFunc("/users/sign_in", usercontroller.SignInHandler).Methods("POST")
 	router.HandleFunc("/users/applications/{application}",
-		helpers.RequireAPIToken(usercontroller.CreateApplicationHandler)).Methods("POST")
+		helpers.RequireAPIToken(applicationcontroller.CreateApplicationHandler)).Methods("POST")
 	router.HandleFunc("/users/applications",
-		helpers.RequireAPIToken(usercontroller.ListApplicationsHandler)).Methods("GET")
+		helpers.RequireAPIToken(applicationcontroller.ListApplicationsHandler)).Methods("GET")
 	router.HandleFunc("/users/applications/{application}",
-		helpers.RequireAPIToken(usercontroller.DeleteApplicationHandler)).Methods("DELETE")
+		helpers.RequireAPIToken(applicationcontroller.DeleteApplicationHandler)).Methods("DELETE")
 
 	return router
 }

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -66,5 +66,13 @@ func createRoutingMux(client *db.Client) *mux.Router {
 	router.HandleFunc("/users/applications/{application}",
 		helpers.RequireAPIToken(applicationcontroller.DeleteApplicationHandler)).Methods("DELETE")
 
+	// Application data routes.
+	router.HandleFunc("/data/{username}/{app_name}",
+		helpers.RequireAppToken(applicationcontroller.ReadApplicationDataHandler)).Methods("GET")
+	router.HandleFunc("/data/{username}/{app_name}",
+		helpers.RequireAppToken(applicationcontroller.SaveApplicationDataHandler)).Methods("POST")
+	router.HandleFunc("/data/{username}/{app_name}",
+		helpers.RequireAppToken(applicationcontroller.DeleteApplicationDataHandler)).Methods("DELETE")
+
 	return router
 }

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -67,11 +67,11 @@ func createRoutingMux(client *db.Client) *mux.Router {
 		helpers.RequireAPIToken(applicationcontroller.DeleteApplicationHandler)).Methods("DELETE")
 
 	// Application data routes.
-	router.HandleFunc("/api/data/{username}/{app_name}",
+	router.HandleFunc("/data/{username}/{app_name}",
 		helpers.RequireAppToken(applicationcontroller.ReadApplicationDataHandler)).Methods("GET")
-	router.HandleFunc("/api/data/{username}/{app_name}",
+	router.HandleFunc("/data/{username}/{app_name}",
 		helpers.RequireAppToken(applicationcontroller.SaveApplicationDataHandler)).Methods("POST")
-	router.HandleFunc("/api/data/{username}/{app_name}",
+	router.HandleFunc("/data/{username}/{app_name}",
 		helpers.RequireAppToken(applicationcontroller.DeleteApplicationDataHandler)).Methods("DELETE")
 
 	return router


### PR DESCRIPTION
:boom: 


Short docs:
Get your applications app token.  It is returned in the list applications endpoint and when creating an application.

Hit the endpoint:
URL `/api/data/{username}/{app_name}` with the `Authorization` header set to your app token.
A GET request reads data, a `POST` writes data, and a `DELETE` deletes data.  
All of the endpoints take a JSON `path` argument in the form `/i/am/a/path` that denotes where to save/read/delete the data.  The create endpoint also takes `data` which can be anything!   See the integration tests for further details.  

Now go forth and develop your backend with Ease.  :+1: 
